### PR TITLE
Allow decimals in ControlNumber

### DIFF
--- a/pyforms/gui/Controls/ControlEmptyWidget.py
+++ b/pyforms/gui/Controls/ControlEmptyWidget.py
@@ -56,15 +56,13 @@ class ControlEmptyWidget(ControlBase, QWidget):
 			for w in value:
 				self.form.layout().addWidget(w.form)
 
-				# The init_form should be called only for the BaseWidget
-				if isinstance(w, BaseWidget) and not w._formLoaded:
-					w.init_form()
 		else:
 			self.form.layout().addWidget(value.form)
-			# The init_form should be called only for the BaseWidget
-			if isinstance(value, BaseWidget) and not value._formLoaded:
-				value.init_form()
 
+		# The init_form should be called only for the BaseWidget
+
+		if isinstance(w, BaseWidget) and not w._formLoaded:
+			w.init_form()
 
 	@property
 	def form(self):

--- a/pyforms/gui/Controls/ControlEmptyWidget.py
+++ b/pyforms/gui/Controls/ControlEmptyWidget.py
@@ -43,7 +43,6 @@ class ControlEmptyWidget(ControlBase, QWidget):
 
 	@value.setter
 	def value(self, value):
-		print("ControlEmptyWidget:", value)
 		ControlBase.value.fset(self, value)
 		self.__clear_layout()
 
@@ -54,9 +53,7 @@ class ControlEmptyWidget(ControlBase, QWidget):
 				if w != None and w != "": self.form.layout().removeWidget(w.form)
 
 		if isinstance(value, list):
-			print("LIST")
 			for w in value:
-				print(w)
 				self.form.layout().addWidget(w.form)
 
 				# The init_form should be called only for the BaseWidget

--- a/pyforms/gui/Controls/ControlEmptyWidget.py
+++ b/pyforms/gui/Controls/ControlEmptyWidget.py
@@ -55,14 +55,13 @@ class ControlEmptyWidget(ControlBase, QWidget):
 		if isinstance(value, list):
 			for w in value:
 				self.form.layout().addWidget(w.form)
-
 		else:
 			self.form.layout().addWidget(value.form)
 
 		# The init_form should be called only for the BaseWidget
 
-		if isinstance(w, BaseWidget) and not w._formLoaded:
-			w.init_form()
+		if isinstance(value, BaseWidget) and not value._formLoaded:
+			value.init_form()
 
 	@property
 	def form(self):

--- a/pyforms/gui/Controls/ControlEmptyWidget.py
+++ b/pyforms/gui/Controls/ControlEmptyWidget.py
@@ -43,6 +43,7 @@ class ControlEmptyWidget(ControlBase, QWidget):
 
 	@value.setter
 	def value(self, value):
+		print("ControlEmptyWidget:", value)
 		ControlBase.value.fset(self, value)
 		self.__clear_layout()
 
@@ -53,15 +54,20 @@ class ControlEmptyWidget(ControlBase, QWidget):
 				if w != None and w != "": self.form.layout().removeWidget(w.form)
 
 		if isinstance(value, list):
+			print("LIST")
 			for w in value:
+				print(w)
 				self.form.layout().addWidget(w.form)
+
+				# The init_form should be called only for the BaseWidget
+				if isinstance(w, BaseWidget) and not w._formLoaded:
+					w.init_form()
 		else:
 			self.form.layout().addWidget(value.form)
+			# The init_form should be called only for the BaseWidget
+			if isinstance(value, BaseWidget) and not value._formLoaded:
+				value.init_form()
 
-		# The init_form should be called only for the BaseWidget
-
-		if isinstance(value, BaseWidget) and not value._formLoaded:
-			value.init_form()
 
 	@property
 	def form(self):

--- a/pyforms/gui/Controls/ControlNumber.py
+++ b/pyforms/gui/Controls/ControlNumber.py
@@ -16,9 +16,11 @@ from pyforms.gui.Controls.ControlBase import ControlBase
 
 
 class ControlNumber(ControlBase):
-	def __init__(self, label="", default=0, minimum=0, maximum=100):
+	def __init__(self, label="", default=0, minimum=0, maximum=100, decimals=0):
 		self._min = minimum
 		self._max = maximum
+		self._decimals = decimals
+		self._updateSpinner = True
 		ControlBase.__init__(self, label, default)
 
 	def init_form(self):
@@ -28,14 +30,14 @@ class ControlNumber(ControlBase):
 		self.value = self._value
 		self.form.label.setAccessibleName('ControlNumber-label')
 		self.form.spinBox.valueChanged.connect(self.value_changed)
-		self.form.spinBox.setDecimals(0)
+		self.form.spinBox.setDecimals(self._decimals)
 		self.min = self._min
 		self.max = self._max
 
 	def value_changed(self, value):
-		self._updateSlider = False
+		self._updateSpinner = False
 		self.value = value
-		self._updateSlider = True
+		self._updateSpinner= True
 
 	############################################################################
 	############ Properties ####################################################
@@ -55,7 +57,8 @@ class ControlNumber(ControlBase):
 	@value.setter
 	def value(self, value):
 		ControlBase.value.fset(self, value)
-		self.form.spinBox.setValue(value)
+		if self._updateSpinner:
+			self.form.spinBox.setValue(value)
 
 	@property
 	def min(self): return self.form.spinBox.minimum()


### PR DESCRIPTION
This adds a `decimals` argument to the `ControlNumber` constructor that will set the number of decimals allowed in the `QDoubleSpinBox`. It also makes sure that the value in the spinbox is not set when the value in the spinbox is changed. This solves an issue with being able to type in the decimals.