### PR TITLE
Added ControlPassword module for password field

### DIFF
--- a/pyforms/Controls.py
+++ b/pyforms/Controls.py
@@ -7,6 +7,7 @@ if conf.PYFORMS_MODE in ['GUI', 'GUI-OPENCSP']:
 
 	from pyforms.gui.Controls.ControlBase import ControlBase
 	from pyforms.gui.Controls.ControlText import ControlText
+	from pyforms.gui.Controls.ControlPassword import ControlPassword	
 	from pyforms.gui.Controls.ControlBoundingSlider import ControlBoundingSlider
 	from pyforms.gui.Controls.ControlButton import ControlButton
 	from pyforms.gui.Controls.ControlCheckBoxList import ControlCheckBoxList

--- a/pyforms/gui/Controls/ControlPassword.py
+++ b/pyforms/gui/Controls/ControlPassword.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from pyforms.gui.Controls.ControlText import ControlText
+
+from pysettings import conf
+
+if conf.PYFORMS_USE_QT5:
+	from PyQt5.QtWidgets import QLineEdit
+else:
+	from PyQt4.QtGui import QLineEdit
+
+class ControlPassword(ControlText):
+    def init_form(self):
+        super(ControlPassword, self).init_form()
+        
+        self.form.label.setAccessibleName('ControlPassword-label')
+        self.form.lineEdit.setEchoMode(QLineEdit.Password)


### PR DESCRIPTION
Added a new `ControlPassword` module which is based off `ControlText` module. Also updated `pyforms/controls.py` to add an import for the same. This module works on desktop and currently is just making use of `.setEchoMode()` method and nothing more.

![image](https://user-images.githubusercontent.com/2759499/29105580-5b481e3c-7cec-11e7-82c4-896b9e003ae0.png)