### PR TITLE
`show_spinboxes` bugfix

### DIFF
--- a/pyforms/gui/Controls/ControlBoundingSlider.py
+++ b/pyforms/gui/Controls/ControlBoundingSlider.py
@@ -326,8 +326,9 @@ class ControlBoundingSlider(ControlBase):
     def __update(self):
         l, h = self._boundingbox._minVal, self._boundingbox._maxVal
         self._is_updating_spinboxes = True
-        self._min_spinbox.setValue(l)
-        self._max_spinbox.setValue(h)
+        if self._show_spinboxes:
+            self._min_spinbox.setValue(l)
+            self._max_spinbox.setValue(h)
         del self._is_updating_spinboxes
         self.changed_event()
 


### PR DESCRIPTION
When `show_spinboxes=False`, the `_update()` method fails with exception as `_min_spinbox` and `_max_spinbox` have not been created by `init_form()`